### PR TITLE
give way to get chart_instance as bin separatelly

### DIFF
--- a/aclk/schema-wrappers/chart_stream.h
+++ b/aclk/schema-wrappers/chart_stream.h
@@ -82,6 +82,7 @@ typedef struct {
 } charts_and_dims_updated_t;
 
 char *generate_charts_and_dimensions_updated(size_t *len, const charts_and_dims_updated_t *updates);
+char *generate_chart_instance_updated(size_t *len, const struct chart_instance_updated *update);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
##### Summary
`generate_chart_instance_updated` allows to store singular chart instance update in binary form in database
after data copied to DB use `freez(pointer_returned)` to clean up the memory
##### Component Name

##### Test Plan

##### Additional Information
