### PR TITLE
Do ACLK sync thread shutdown for a host

### DIFF
--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -160,6 +160,7 @@ void aclk_status_chart_event(struct aclk_database_worker_config *wc, struct aclk
 void aclk_reset_node_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_fetch_chart_event_proto(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_push_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void sql_drop_host_aclk_table_list(uuid_t *host_uuid);
 void aclk_start_streaming(char *node_id);
 void sql_aclk_drop_all_table_list();
 extern void aclk_set_architecture(int mode);


### PR DESCRIPTION
aclk_sync commands to 
- Stop ACLK sync thread (stop_thread=1)
- Drop tables (drop_tables=1)
- Recreate tables (create_tables=1) (restarts ACLK sync thread if non-active)
