### PR TITLE
Restore old non-sql calls for health

### DIFF
--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -110,12 +110,12 @@ extern int alert_hash_and_store_config(
     const char *repeat,
     const char *host_labels);
 extern void sql_select_alert_config(char *hash_str, BUFFER *wb);
-extern void sql_create_health_log_table(RRDHOST *host);
-extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
-extern void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
-extern void health_alarm_entry_sql2json(BUFFER *wb, uint32_t unique_id, uint32_t alarm_id, RRDHOST *host);
-extern void sql_health_alarm_log_select_all(BUFFER *wb, RRDHOST *host);
-extern void sql_health_alarm_log_load(RRDHOST *host);
+//extern void sql_create_health_log_table(RRDHOST *host);
+//extern void sql_health_alarm_log_save(RRDHOST *host, ALARM_ENTRY *ae);
+//extern void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae);
+//extern void health_alarm_entry_sql2json(BUFFER *wb, uint32_t unique_id, uint32_t alarm_id, RRDHOST *host);
+//extern void sql_health_alarm_log_select_all(BUFFER *wb, RRDHOST *host);
+//extern void sql_health_alarm_log_load(RRDHOST *host);
 extern int execute_insert(sqlite3_stmt *res);
 extern void compute_chart_hash(RRDSET *st);
 extern void sql_chart_from_hash_id(char *hash_str, BUFFER *wb);

--- a/health/health.c
+++ b/health/health.c
@@ -358,8 +358,6 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_RUN;
     ae->exec_run_timestamp = now_realtime_sec(); /* will be updated by real time after spawning */
 
-    sql_health_alarm_log_save(host, ae);
-
     debug(D_HEALTH, "executing command '%s'", command_to_run);
     ae->flags |= HEALTH_ENTRY_FLAG_EXEC_IN_PROGRESS;
     ae->exec_spawn_serial = spawn_enq_cmd(command_to_run);
@@ -367,8 +365,7 @@ static inline void health_alarm_execute(RRDHOST *host, ALARM_ENTRY *ae) {
 
     return; //health_alarm_wait_for_execution
 done:
-    //health_alarm_log_save(host, ae);
-    sql_health_alarm_log_save(host, ae);
+    health_alarm_log_save(host, ae);
 }
 
 static inline void health_alarm_wait_for_execution(ALARM_ENTRY *ae) {

--- a/health/health_json.c
+++ b/health/health_json.c
@@ -145,29 +145,29 @@ void health_alarm_log2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *char
     netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
 }
 
-void health_alarm_log_sql2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart) {
-    netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock);
+/* void health_alarm_log_sql2json(RRDHOST *host, BUFFER *wb, uint32_t after, char *chart) { */
+/*     netdata_rwlock_rdlock(&host->health_log.alarm_log_rwlock); */
 
-    buffer_strcat(wb, "[");
+/*     buffer_strcat(wb, "["); */
 
-    unsigned int max = host->health_log.max;
-    unsigned int count = 0;
-    uint32_t hash_chart = 0;
-    if (chart) hash_chart = simple_hash(chart);
-    ALARM_ENTRY *ae;
-    for (ae = host->health_log.alarms; ae && count < max; ae = ae->next) {
-        if ((ae->unique_id > after) && (!chart || (ae->hash_chart == hash_chart && !strcmp(ae->chart, chart)))) {
-            if (likely(count))
-                buffer_strcat(wb, ",");
-            health_alarm_entry_sql2json(wb, ae->unique_id, ae->alarm_id, host);
-            count++;
-        }
-    }
+/*     unsigned int max = host->health_log.max; */
+/*     unsigned int count = 0; */
+/*     uint32_t hash_chart = 0; */
+/*     if (chart) hash_chart = simple_hash(chart); */
+/*     ALARM_ENTRY *ae; */
+/*     for (ae = host->health_log.alarms; ae && count < max; ae = ae->next) { */
+/*         if ((ae->unique_id > after) && (!chart || (ae->hash_chart == hash_chart && !strcmp(ae->chart, chart)))) { */
+/*             if (likely(count)) */
+/*                 buffer_strcat(wb, ","); */
+/*             health_alarm_entry_sql2json(wb, ae->unique_id, ae->alarm_id, host); */
+/*             count++; */
+/*         } */
+/*     } */
 
-    buffer_strcat(wb, "\n]\n");
+/*     buffer_strcat(wb, "\n]\n"); */
 
-    netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock);
-}
+/*     netdata_rwlock_unlock(&host->health_log.alarm_log_rwlock); */
+/* } */
 
 static inline void health_rrdcalc_values2json_nolock(RRDHOST *host, BUFFER *wb, RRDCALC *rc) {
     (void)host;

--- a/web/api/web_api_v1.c
+++ b/web/api/web_api_v1.c
@@ -296,27 +296,27 @@ inline int web_client_api_request_v1_alarm_log(RRDHOST *host, struct web_client 
     return HTTP_RESP_OK;
 }
 
-inline int web_client_api_request_v1_alarm_log_sql(RRDHOST *host, struct web_client *w, char *url) {
-    uint32_t after = 0;
-    char *chart = NULL;
+/* inline int web_client_api_request_v1_alarm_log_sql(RRDHOST *host, struct web_client *w, char *url) { */
+/*     uint32_t after = 0; */
+/*     char *chart = NULL; */
 
-    while(url) {
-        char *value = mystrsep(&url, "&");
-        if (!value || !*value) continue;
+/*     while(url) { */
+/*         char *value = mystrsep(&url, "&"); */
+/*         if (!value || !*value) continue; */
 
-        char *name = mystrsep(&value, "=");
-        if(!name || !*name) continue;
-        if(!value || !*value) continue;
+/*         char *name = mystrsep(&value, "="); */
+/*         if(!name || !*name) continue; */
+/*         if(!value || !*value) continue; */
 
-        if (!strcmp(name, "after")) after = (uint32_t)strtoul(value, NULL, 0);
-        else if (!strcmp(name, "chart")) chart = value;
-    }
+/*         if (!strcmp(name, "after")) after = (uint32_t)strtoul(value, NULL, 0); */
+/*         else if (!strcmp(name, "chart")) chart = value; */
+/*     } */
 
-    buffer_flush(w->response.data);
-    w->response.data->contenttype = CT_APPLICATION_JSON;
-    health_alarm_log_sql2json(host, w->response.data, after, chart);
-    return HTTP_RESP_OK;
-}
+/*     buffer_flush(w->response.data); */
+/*     w->response.data->contenttype = CT_APPLICATION_JSON; */
+/*     health_alarm_log_sql2json(host, w->response.data, after, chart); */
+/*     return HTTP_RESP_OK; */
+/* } */
 
 int web_client_api_request_v1_alarm_config (RRDHOST *host __maybe_unused, struct web_client *w, char *url) {
     char *config_hash_id = NULL;
@@ -1432,7 +1432,7 @@ static struct api_command {
         { "alarms",          0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarms          },
         { "alarms_values",   0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarms_values   },
         { "alarm_log",       0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_log       },
-        { "alarm_log_sql",   0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_log_sql   },
+        /* { "alarm_log_sql",   0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_log_sql   }, */
         { "alarm_variables", 0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_variables },
         { "alarm_count",     0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_count     },
         { "alarm_config",    0, WEB_CLIENT_ACL_DASHBOARD, web_client_api_request_v1_alarm_config    },


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Restores the calls to use the health log, and to send it to cloud via the old way (`aclk_update_alarm`)

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
