### PR TITLE
Alerts stream attempt 1

### DIFF
--- a/aclk/aclk_rx_msgs.c
+++ b/aclk/aclk_rx_msgs.c
@@ -347,13 +347,13 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
     }
     if (!strcmp(message_type, "StartAlarmStreaming")) {
         struct start_alarm_streaming res = parse_start_alarm_streaming(msg, msg_len);
-        if (!res.node_id) {
+        if (!res.node_id || !res.batch_id) {
             error("Error parsing StartAlarmStreaming");
             freez(res.node_id);
             return;
         }
         //TODO stelfrag/MrZammler call your handler here
-        aclk_start_alert_streaming(res.node_id);
+        aclk_start_alert_streaming(res.node_id, res.batch_id, res.start_seq_id);
         freez(res.node_id);
         return;
     }
@@ -364,6 +364,7 @@ void aclk_handle_new_cloud_msg(const char *message_type, const char *msg, size_t
             return;
         }
         //TODO stelfrag/MrZammler call your handler here
+        aclk_send_alarm_health_log(node_id);
         freez(node_id);
         return;
     }

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -8,8 +8,6 @@
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
 
-#define ACLK_LOG_CONVERSATION_DIR "/tmp/aclk-messages/"
-
 extern int aclk_use_new_cloud_arch;
 
 typedef enum {

--- a/aclk/aclk_util.h
+++ b/aclk/aclk_util.h
@@ -8,6 +8,8 @@
 // Helper stuff which should not have any further inside ACLK dependency
 // and are supposed not to be needed outside of ACLK
 
+#define ACLK_LOG_CONVERSATION_DIR "/tmp/aclk-messages/"
+
 extern int aclk_use_new_cloud_arch;
 
 typedef enum {

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -137,7 +137,7 @@ void aclk_database_worker(void *arg)
     unsigned cmd_batch_size;
 
     wc->chart_updates = 0;
-    wc->alert_updates = 1;
+    wc->alert_updates = 0;
 
     aclk_database_init_cmd_queue(wc);
     uv_thread_set_name_np(wc->thread, wc->uuid_str);
@@ -232,6 +232,10 @@ void aclk_database_worker(void *arg)
                 case ACLK_DATABASE_PUSH_ALERT:
                     debug(D_ACLK_SYNC, "Pushing alert info to the cloud for node %s", wc->uuid_str);
                     aclk_push_alert_event(wc, cmd);
+                    break;
+                case ACLK_DATABASE_ALARM_HEALTH_LOG:
+                    debug(D_ACLK_SYNC, "Pushing alarm health log to the cloud for node %s", wc->uuid_str);
+                    aclk_push_alarm_health_log(wc, cmd);
                     break;
                 case ACLK_DATABASE_ADD_DIMENSION:
                     debug(D_ACLK_SYNC,"Adding dimension event for %s", wc->uuid_str);
@@ -811,37 +815,37 @@ void aclk_start_streaming(char *node_id, uint64_t sequence_id, time_t created_at
 }
 
 // Start streaming alerts
-void aclk_start_alert_streaming(char *node_id)
+void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start_seq_id)
 {
     if (unlikely(!node_id))
         return;
 
     info("START streaming alerts for %s received", node_id);
-    debug(D_ACLK_SYNC, "START streaming alerts for %s received", node_id);
-    
 
-   uuid_t node_uuid;
-   uuid_parse(node_id, node_uuid);
+    uuid_t node_uuid;
+    uuid_parse(node_id, node_uuid);
 
-   struct aclk_database_worker_config *wc  = NULL;
-   rrd_wrlock();
-   RRDHOST *host = localhost;
-   while(host) {
-       if (host->node_id && !(uuid_compare(*host->node_id, node_uuid))) {
-           wc = (struct aclk_database_worker_config *)host->dbsync_worker;
-           if (likely(wc)) {
-               wc->alert_updates = 1;
-               info("START streaming alerts for %s enabled", node_id);
-           }
-           else
-               error("ACLK synchronization thread is not active for host %s", host->hostname);
-           break;
-       }
-       host = host->next;
-   }
-   rrd_unlock();
+    struct aclk_database_worker_config *wc  = NULL;
+    rrd_wrlock();
+    RRDHOST *host = localhost;
+    while(host) {
+        if (host->node_id && !(uuid_compare(*host->node_id, node_uuid))) {
+            wc = (struct aclk_database_worker_config *)host->dbsync_worker;
+            if (likely(wc)) {
+                wc->alert_updates = 1;
+                wc->alerts_batch_id = batch_id;
+                wc->alerts_start_seq_id = start_seq_id;
+                info("START streaming alerts for %s enabled with batch_id %ld and start_seq_id %ld", node_id, batch_id, start_seq_id);
+            }
+            else
+                error("ACLK synchronization thread is not active for host %s", host->hostname);
+            break;
+        }
+        host = host->next;
+    }
+    rrd_unlock();
 
-   return;
+    return;
 }
 
 void aclk_push_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
@@ -1338,12 +1342,42 @@ int aclk_add_alert_event(struct aclk_database_worker_config *wc, struct aclk_dat
 
 bind_fail:
     if (unlikely(sqlite3_finalize(res_alert) != SQLITE_OK))
-        error_report("Failed to reset statement in store chart payload, rc = %d", rc);
+        error_report("Failed to reset statement in store alert event, rc = %d", rc);
     buffer_free(sql);
     return (rc != SQLITE_DONE);
 
     freez(cmd.data);
     return rc;
+}
+
+int rrdcalc_status_to_proto_enum(RRDCALC_STATUS status)
+{
+    switch(status) {
+    case RRDCALC_STATUS_REMOVED:
+        return ALARM_STATUS_REMOVED;
+
+    case RRDCALC_STATUS_UNDEFINED:
+        return ALARM_STATUS_NOT_A_NUMBER;
+
+    /* case RRDCALC_STATUS_UNINITIALIZED: */
+    /*     return "UNINITIALIZED"; */
+
+    case RRDCALC_STATUS_CLEAR:
+        return ALARM_STATUS_CLEAR;
+
+        /* case RRDCALC_STATUS_RAISED: */
+        /*     return "RAISED"; */
+
+    case RRDCALC_STATUS_WARNING:
+        return ALARM_STATUS_WARNING;
+
+    case RRDCALC_STATUS_CRITICAL:
+        return ALARM_STATUS_CRITICAL;
+
+    default:
+        error("Unknown alarm status %d", status);
+        return ALARM_STATUS_UNKNOWN;
+    }
 }
 
 void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
@@ -1356,12 +1390,22 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
 
     int limit = cmd.count > 0 ? cmd.count : 1;
     int available = 0;
-    uint64_t first_sequence = 0;
-    uint64_t last_sequence = 0;
-    time_t last_timestamp;
+    /* uint64_t first_sequence = 0; */
+    /* uint64_t last_sequence = 0; */
+    /* time_t last_timestamp; */
     char uuid_str[GUID_LEN + 1];
-
     BUFFER *sql = buffer_create(1024);
+
+    //check if we're in sync with cloud, via start_seq_id
+    //if not, reset sequence ids. If not there, problem
+    //this is not ideal, since we'll query the db more than needed
+    if (wc->alerts_start_seq_id != 0) {
+        buffer_sprintf(sql, "UPDATE aclk_alert_%s SET date_submitted = NULL WHERE sequence_id >= %"PRIu64";",
+                       wc->uuid_str, wc->alerts_start_seq_id);
+        db_execute(buffer_tostring(sql));
+        buffer_reset(sql);
+        wc->alerts_start_seq_id = 0;
+    }
 
     sqlite3_stmt *res = NULL;
 
@@ -1372,48 +1416,51 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
                          from health_log_%s hl, aclk_alert_%s aa \
                          where hl.unique_id = aa.alert_unique_id and aa.date_submitted is null \
                          order by aa.sequence_id asc limit %d;", wc->uuid_str, wc->uuid_str, limit);
-    
+
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0);
     if (rc != SQLITE_OK) {
         error_report("Failed to prepare statement to get health entries from the database");
         goto fail_complete;
     }
 
-    //struct alarm_log_entry *alarm_log = callocz(limit+1, sizeof(*alarm_log));
+
 
     int count = 0;
     char *claim_id = is_agent_claimed();
     while (sqlite3_step(res) == SQLITE_ROW) {
 
         struct alarm_log_entry alarm_log;
+        char old_value_string[100 + 1];
+        char new_value_string[100 + 1];
 
         uuid_unparse_lower(*((uuid_t *) sqlite3_column_blob(res, 3)), uuid_str);
 
         alarm_log.node_id = get_str_from_uuid(wc->host->node_id);
-        alarm_log.claim_id = strdupz((char *)claim_id); //will need free
-        
+        alarm_log.claim_id = strdupz((char *)claim_id);
+
         alarm_log.chart = strdupz((char *)sqlite3_column_text(res, 12));
         alarm_log.name = strdupz((char *)sqlite3_column_text(res, 11));
         alarm_log.family = sqlite3_column_bytes(res, 13) > 0 ? strdupz((char *)sqlite3_column_text(res, 13)) : NULL;
-        
-        alarm_log.batch_id = 1;//wc->alerts_batch_id;
+
+        alarm_log.batch_id = wc->alerts_batch_id;
         alarm_log.sequence_id = (uint64_t) sqlite3_column_int64(res, 0);
         alarm_log.when = (uint64_t) sqlite3_column_int64(res, 5);
 
         alarm_log.config_hash = strdupz((char *)uuid_str);
 
-        alarm_log.utc_offset = 0; //fix!!!
-        alarm_log.timezone = strdupz((char *)wc->host->timezone);
+        alarm_log.utc_offset = 10; //fix!!!
+        alarm_log.timezone = strdupz((char *)"EEST"); //fix
 
         alarm_log.exec_path = sqlite3_column_bytes(res, 14) > 0 ? strdupz((char *)sqlite3_column_text(res, 14)) : strdupz((char *)wc->host->health_default_exec);
         alarm_log.conf_source = strdupz((char *)sqlite3_column_text(res, 16));
         alarm_log.command = strdupz((char *)sqlite3_column_text(res, 16)); //fix, do edit_command
 
         alarm_log.duration = (uint32_t) sqlite3_column_int(res, 6); //correct ?
-        alarm_log.non_clear_duration = (uint32_t) sqlite3_column_int(res, 7);
+        alarm_log.non_clear_duration = (uint32_t) sqlite3_column_int(res, 7); //correct?
 
-        alarm_log.status = 4; //fix!!!
-        alarm_log.old_status = 4; //fix!!!
+
+        alarm_log.status = rrdcalc_status_to_proto_enum((RRDCALC_STATUS) sqlite3_column_int(res, 20));
+        alarm_log.old_status = rrdcalc_status_to_proto_enum((RRDCALC_STATUS) sqlite3_column_int(res, 21));
 
         alarm_log.delay = (uint64_t) sqlite3_column_int64(res, 22);
         alarm_log.delay_up_to_timestamp = (uint64_t) sqlite3_column_int64(res, 10);
@@ -1421,23 +1468,139 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
 
         alarm_log.silenced = 0; //FIX!!!
 
-        alarm_log.value_string = strdupz((char *)"0%"); //fix!!!
-        alarm_log.old_value_string = strdupz((char *)"0%"); //fix!!!
+        alarm_log.value_string = sqlite3_column_type(res, 23) == SQLITE_NULL ? "-" : strdupz((char *)format_value_and_unit(new_value_string, 100, sqlite3_column_double(res, 23), (char *) sqlite3_column_text(res, 17), -1));
+        alarm_log.old_value_string = sqlite3_column_type(res, 24) == SQLITE_NULL ? "-" : strdupz((char *)format_value_and_unit(new_value_string, 100, sqlite3_column_double(res, 24), (char *) sqlite3_column_text(res, 17), -1));
 
         alarm_log.value = (double) sqlite3_column_double(res, 23);
         alarm_log.old_value = (double) sqlite3_column_double(res, 24);
 
-        alarm_log.updated = (sqlite3_column_int(res, 8) & HEALTH_ENTRY_FLAG_UPDATED) ? 1 : 0;
-        
-        alarm_log.rendered_info = strdupz((char *)sqlite3_column_text(res, 18));
-        
+        alarm_log.updated = (sqlite3_column_int(res, 8) & HEALTH_ENTRY_FLAG_UPDATED) ? 1 : 0; //check when 0
+
+        alarm_log.rendered_info = strdupz((char *)sqlite3_column_text(res, 18)); //check, should be already ok?
+
+        info("DEBUG: %s pushing alert seq %" PRIu64 " - %" PRIu64"", wc->uuid_str, (uint64_t) sqlite3_column_int64(res, 0), (uint64_t) sqlite3_column_int64(res, 1));
         aclk_send_alarm_log_entry(&alarm_log);
-        count++;
+
+        buffer_sprintf(sql, "UPDATE aclk_alert_%s SET date_submitted=strftime('%%s') "
+                       "WHERE sequence_id = %" PRIu64 " AND alert_unique_id = %" PRIu64 ";",
+                       wc->uuid_str, (uint64_t) sqlite3_column_int64(res, 0), (uint64_t) sqlite3_column_int64(res, 1));
+
+        db_execute(buffer_tostring(sql));
     }
 
-    
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to finalize statement to send Alarm Entries from the database, rc = %d", rc);
+        goto fail_complete;
+    }
+
+
+
 
     //need stuff
+    freez(claim_id);
+
+fail_complete:
+    buffer_free(sql);
+#endif
+
+    return;
+}
+
+void aclk_send_alarm_health_log(char *node_id)
+{
+    struct aclk_database_worker_config *wc  = NULL;
+
+    rrd_wrlock();
+    RRDHOST *host = find_host_by_node_id(node_id);
+    if (likely(host)) {
+        wc = (struct aclk_database_worker_config *)host->dbsync_worker;
+        rrd_unlock();
+        if (likely(wc)) {
+            struct aclk_database_cmd cmd;
+            cmd.opcode = ACLK_DATABASE_ALARM_HEALTH_LOG;
+            //cmd.param1 = param;
+            cmd.completion = NULL;
+            aclk_database_enq_cmd(wc, &cmd);
+        } else
+            error("ACLK synchronization thread is not active for host %s", host->hostname);
+    }
+    else
+        rrd_unlock(); //is this ok ???
+    return;
+}
+
+void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd)
+{
+#ifndef ACLK_NG
+    UNUSED (wc);
+    UNUSED(cmd);
+#else
+    int rc;
+
+    int available = 0;
+    uint64_t first_sequence = 0;
+    uint64_t last_sequence = 0;
+    struct timeval first_timestamp;
+    struct timeval last_timestamp;
+    char uuid_str[GUID_LEN + 1];
+
+    BUFFER *sql = buffer_create(1024);
+
+    sqlite3_stmt *res = NULL;
+
+    buffer_sprintf(sql, "select aa.sequence_id, aa.date_submitted, \
+                         (select laa.sequence_id from aclk_alert_%s laa \
+                         where laa.date_submitted is not null order by laa.sequence_id desc limit 1), \
+                         (select laa.date_submitted from aclk_alert_%s laa \
+                         where laa.date_submitted is not null order by laa.sequence_id desc limit 1) \
+                         from aclk_alert_%s aa where aa.date_submitted is not null order by aa.sequence_id asc limit 1;", wc->uuid_str, wc->uuid_str, wc->uuid_str);
+
+    rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0);
+    if (rc != SQLITE_OK) {
+        error_report("Failed to prepare statement to get health log statistics from the database");
+        goto fail_complete;
+    }
+
+    first_timestamp.tv_sec = 0;
+    first_timestamp.tv_usec = 0;
+    last_timestamp.tv_sec = 0;
+    last_timestamp.tv_usec = 0;
+
+    while (sqlite3_step(res) == SQLITE_ROW) {
+        first_sequence = sqlite3_column_bytes(res, 0) > 0 ? (uint64_t) sqlite3_column_int64(res, 0) : 0;
+        if (sqlite3_column_bytes(res, 1) > 0) {
+            first_timestamp.tv_sec = sqlite3_column_int64(res, 1);
+        }
+
+        last_sequence = sqlite3_column_bytes(res, 2) > 0 ? (uint64_t) sqlite3_column_int64(res, 2) : 0;
+        if (sqlite3_column_bytes(res, 3) > 0) {
+            last_timestamp.tv_sec = sqlite3_column_int64(res, 3);
+        }
+    }
+
+    rc = sqlite3_finalize(res);
+    if (unlikely(rc != SQLITE_OK)) {
+        error_report("Failed to reset statement to get health log statistics from the database, rc = %d", rc);
+        goto fail_complete;
+    }
+
+    struct alarm_log_entries log_entries;
+    log_entries.first_seq_id = first_sequence;
+    log_entries.first_when = first_timestamp;
+    log_entries.last_seq_id = last_sequence;
+    log_entries.last_when = last_timestamp;
+
+    struct alarm_log_health alarm_log;
+    char *claim_id = is_agent_claimed();
+    alarm_log.claim_id = strdupz((char *)claim_id);
+    alarm_log.node_id = get_str_from_uuid(wc->host->node_id);
+    alarm_log.log_entries = log_entries;
+    alarm_log.status = wc->alert_updates == 0 ? 2 : 1;
+
+    aclk_send_alarm_log_health(&alarm_log);
+
+    freez(claim_id);
 
 fail_complete:
     buffer_free(sql);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -8,6 +8,7 @@
 #include "../../aclk/schema-wrappers/chart_stream.h"
 
 #define ACLK_MAX_CHART_UPDATES  (5)
+#define ACLK_MAX_ALERT_UPDATES  (5)
 
 static inline void uuid_unparse_lower_fix(uuid_t *uuid, char *out)
 {
@@ -46,7 +47,8 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
         "end;"
 
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
-        "alert_unique_id, date_created, date_submitted); "
+        "alert_unique_id, date_created, date_submitted, " \
+        "unique(alert_unique_id));"
 
 enum aclk_database_opcode {
     ACLK_DATABASE_NOOP = 0,
@@ -66,7 +68,8 @@ enum aclk_database_opcode {
     ACLK_DATABASE_DEDUP_CHART,
     ACLK_DATABASE_UPD_STATS,
     ACLK_DATABASE_SYNC_CHART_SEQ,
-    ACLK_DATABASE_MAX_OPCODE
+    ACLK_DATABASE_MAX_OPCODE,
+    ACLK_DATABASE_PUSH_ALERT
 };
 
 struct aclk_chart_payload_t {
@@ -100,6 +103,7 @@ struct aclk_database_worker_config {
     uint64_t chart_sequence_id;     // last chart_sequence_id
     time_t chart_timestamp;         // last chart timestamp
     uint64_t batch_id;    // batch id to use
+    uint64_t alerts_batch_id; // batch id for alerts to use
     uv_loop_t *loop;
     RRDHOST *host;
     uv_async_t async;
@@ -144,6 +148,7 @@ int aclk_add_dimension_event(struct aclk_database_worker_config *wc, struct aclk
 int aclk_push_chart_config_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 //int aclk_add_alert_event(RRDHOST *host, ALARM_ENTRY *ae, struct completion *completion);
 int aclk_add_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 //void aclk_fetch_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void sql_reset_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -69,7 +69,8 @@ enum aclk_database_opcode {
     ACLK_DATABASE_UPD_STATS,
     ACLK_DATABASE_SYNC_CHART_SEQ,
     ACLK_DATABASE_MAX_OPCODE,
-    ACLK_DATABASE_PUSH_ALERT
+    ACLK_DATABASE_PUSH_ALERT,
+    ACLK_DATABASE_ALARM_HEALTH_LOG
 };
 
 struct aclk_chart_payload_t {
@@ -104,6 +105,7 @@ struct aclk_database_worker_config {
     time_t chart_timestamp;         // last chart timestamp
     uint64_t batch_id;    // batch id to use
     uint64_t alerts_batch_id; // batch id for alerts to use
+    uint64_t alerts_start_seq_id; // cloud has asked to start streaming from
     uv_loop_t *loop;
     RRDHOST *host;
     uv_async_t async;
@@ -149,6 +151,8 @@ int aclk_push_chart_config_event(struct aclk_database_worker_config *wc, struct 
 //int aclk_add_alert_event(RRDHOST *host, ALARM_ENTRY *ae, struct completion *completion);
 int aclk_add_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
+void aclk_send_alarm_health_log(char *node_id);
+void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 //void aclk_fetch_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void sql_reset_chart_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void sql_build_node_info(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
@@ -160,7 +164,7 @@ void sql_drop_host_aclk_table_list(uuid_t *host_uuid);
 void aclk_ack_chart_sequence_id(char *node_id, uint64_t last_sequence_id);
 void aclk_get_chart_config(char **hash_id_list);
 void aclk_start_streaming(char *node_id, uint64_t seq_id, time_t created_at, uint64_t batch_id);
-void aclk_start_alert_streaming(char *node_id);
+void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start_seq_id);
 void sql_aclk_drop_all_table_list();
 void sql_set_chart_ack(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_submit_param_command(char *node_id, enum aclk_database_opcode aclk_command, uint64_t param);

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2937,6 +2937,7 @@ void health_alarm_entry_sql2json(BUFFER *wb, uint32_t unique_id, uint32_t alarm_
             (long unsigned int)sqlite3_column_int(res, 27),
             (sqlite3_column_int(res, 10) & HEALTH_ENTRY_FLAG_SILENCED)?"true":"false");
 
+        //not needed, it's already stored with replaced info
             char *replaced_info = NULL;
             if (likely(sqlite3_column_text(res, 20))) {
                 char *m = NULL;


### PR DESCRIPTION
##### Summary

First attempt at alerts streaming.

Responds to `SendAlarmLogHealth` (first message after connection for Alerts), with `AlarmLogHealth` which informs cloud of the current status (status, first_sequence_id, first_when, last_sequence_id, last_when). Those currently are from the aclk_alert_xxxx table. We'll see if correct.

Next message comes from cloud: `StartAlarmStreaming` and indicates the batch_id and a start_seq_id. From then on, `AlarmLogEntry` starts and sends log entries to the cloud.

Because of the decision to send everything but log entries in status Uninitialized, there will be a lot of messages.

##### Component Name

##### Test Plan

<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
