### PR TITLE
Work with sql health log on new agents

### DIFF
--- a/database/rrdhost.c
+++ b/database/rrdhost.c
@@ -306,7 +306,6 @@ RRDHOST *rrdhost_create(const char *hostname,
                 int rc = sql_create_health_log_table(host);
                 if (unlikely(rc)) {
                     error_report("Failed to create health log table in the database");
-
                     health_alarm_log_load(host);
                     health_alarm_log_open(host);
                 }

--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -1458,8 +1458,6 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
         goto fail_complete;
     }
 
-
-
     int count = 0;
     char *claim_id = is_agent_claimed();
     while (sqlite3_step(res) == SQLITE_ROW) {
@@ -1529,9 +1527,6 @@ void aclk_push_alert_event(struct aclk_database_worker_config *wc, struct aclk_d
         error_report("Failed to finalize statement to send Alarm Entries from the database, rc = %d", rc);
         goto fail_complete;
     }
-
-
-
 
     //need stuff
     freez(claim_id);
@@ -1633,6 +1628,8 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
     alarm_log.node_id = get_str_from_uuid(wc->host->node_id);
     alarm_log.log_entries = log_entries;
     alarm_log.status = wc->alert_updates == 0 ? 2 : 1;
+
+    wc->alert_sequence_id = last_sequence;
 
     aclk_send_alarm_log_health(&alarm_log);
     freez(alarm_log.claim_id);

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -107,6 +107,7 @@ struct aclk_database_worker_config {
     uint64_t batch_id;    // batch id to use
     uint64_t alerts_batch_id; // batch id for alerts to use
     uint64_t alerts_start_seq_id; // cloud has asked to start streaming from
+    uint64_t alert_sequence_id; // last alert sequence_id
     uv_loop_t *loop;
     RRDHOST *host;
     uv_async_t async;

--- a/health/health_log.c
+++ b/health/health_log.c
@@ -454,8 +454,6 @@ inline void health_alarm_log_load(RRDHOST *host) {
         health_alarm_log_read(host, fp, host->health_log_filename);
         fclose(fp);
     }
-
-    health_alarm_log_open(host);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
There was a stray `health_alarm_log_open` which opened the health-log.db file (and if it is opened the agent assumes the file instead of the db will be used to store the log).