### PR TITLE
Report the first and last sequence ids, regardless of whether they were submitted to the cloud

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -1580,12 +1580,12 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
 
     sqlite3_stmt *res = NULL;
 
-    buffer_sprintf(sql, "select aa.sequence_id, aa.date_submitted, \
+    buffer_sprintf(sql, "select aa.sequence_id, aa.date_created, \
                          (select laa.sequence_id from aclk_alert_%s laa \
-                         where laa.date_submitted is not null order by laa.sequence_id desc limit 1), \
-                         (select laa.date_submitted from aclk_alert_%s laa \
-                         where laa.date_submitted is not null order by laa.sequence_id desc limit 1) \
-                         from aclk_alert_%s aa where aa.date_submitted is not null order by aa.sequence_id asc limit 1;", wc->uuid_str, wc->uuid_str, wc->uuid_str);
+                         order by laa.sequence_id desc limit 1), \
+                         (select laa.date_created from aclk_alert_%s laa \
+                         order by laa.sequence_id desc limit 1) \
+                         from aclk_alert_%s aa order by aa.sequence_id asc limit 1;", wc->uuid_str, wc->uuid_str, wc->uuid_str);
 
     rc = sqlite3_prepare_v2(db_meta, buffer_tostring(sql), -1, &res, 0);
     if (rc != SQLITE_OK) {

--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2541,7 +2541,7 @@ void sql_health_alarm_log_update(RRDHOST *host, ALARM_ENTRY *ae) {
         goto failed;
     }
 
-    rc = sqlite3_bind_int(res, 2, ae->flags);
+    rc = sqlite3_bind_int64(res, 2, (uint64_t)ae->flags);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind flags parameter for SQL_UPDATE_HEALTH_LOG");
         goto failed;
@@ -2667,7 +2667,7 @@ void sql_health_alarm_log_insert(RRDHOST *host, ALARM_ENTRY *ae) {
         goto failed;
     }
 
-    rc = sqlite3_bind_int(res, 11, ae->flags);
+    rc = sqlite3_bind_int64(res, 11, (uint64_t)ae->flags);
     if (unlikely(rc != SQLITE_OK)) {
         error_report("Failed to bind flags parameter for SQL_INSERT_HEALTH_LOG");
         goto failed;
@@ -3233,7 +3233,7 @@ void sql_health_alarm_log_load(RRDHOST *host) {
         ae->duration = sqlite3_column_int(res, 8);
         ae->non_clear_duration = sqlite3_column_int(res, 9);
 
-        ae->flags = sqlite3_column_int(res, 10);
+        ae->flags = sqlite3_column_int64(res, 10);
         ae->flags |= HEALTH_ENTRY_FLAG_SAVED;
 
         ae->exec_run_timestamp = sqlite3_column_int(res, 11);


### PR DESCRIPTION
When sending the `AlarmLogHealth` message, the cloud wants the sequence ids in our database, regardless of whether or not they where sent to the cloud.

Plus, use bind_int64 for the flags on the health log db.