### PR TITLE
Check for removed alerts statuses after startup and on health reload

### DIFF
--- a/aclk/aclk.c
+++ b/aclk/aclk.c
@@ -28,6 +28,8 @@ int aclk_disable_single_updates = 0;
 int aclk_kill_link = 0;
 int chart_batch_id;
 
+int aclk_alert_reloaded = 1; //1 on startup, and again on health_reload
+
 int aclk_pubacks_per_conn = 0; // How many PubAcks we got since MQTT conn est.
 
 time_t aclk_block_until = 0;

--- a/aclk/aclk.h
+++ b/aclk/aclk.h
@@ -26,6 +26,7 @@ extern int aclk_kill_link;
 extern int aclk_connected;
 extern int chart_batch_id;
 
+extern int aclk_alert_reloaded;
 extern time_t aclk_block_until;
 
 extern usec_t aclk_session_us;

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -103,7 +103,7 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
         "alert_unique_id, date_created, date_submitted, " \
         "unique(alert_unique_id)); " \
         "insert into aclk_alert_%s (alert_unique_id, date_created) " \
-        "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 order by unique_id asc;"
+        "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 and new_status <> -2 order by unique_id asc on conflict (alert_unique_id) do nothing;"
 
 #define INDEX_ACLK_CHART "CREATE INDEX IF NOT EXISTS aclk_chart_index_%s ON aclk_chart_%s (unique_id);"
 

--- a/database/sqlite/sqlite_aclk_alert.h
+++ b/database/sqlite/sqlite_aclk_alert.h
@@ -14,5 +14,6 @@ void aclk_push_alarm_health_log(struct aclk_database_worker_config *wc, struct a
 void aclk_send_alarm_configuration (char *config_hash);
 int aclk_push_alert_config_event(struct aclk_database_worker_config *wc, struct aclk_database_cmd cmd);
 void aclk_start_alert_streaming(char *node_id, uint64_t batch_id, uint64_t start_seq_id);
+void sql_queue_removed_alerts_to_aclk(RRDHOST *host);
 
 #endif //NETDATA_SQLITE_ACLK_ALERT_H

--- a/database/sqlite/sqlite_health.c
+++ b/database/sqlite/sqlite_health.c
@@ -762,6 +762,8 @@ void sql_health_alarm_log_load(RRDHOST *host) {
             alarm_id = rrdcalc_get_unique_id(host, (const char *) sqlite3_column_text(res, 14), (const char *) sqlite3_column_text(res, 13), NULL);
         ae->alarm_id = alarm_id;
 
+        uuid_copy(ae->config_hash_id, *((uuid_t *) sqlite3_column_blob(res, 4)));
+
         ae->alarm_event_id = sqlite3_column_int(res, 3);
         ae->updated_by_id = sqlite3_column_int(res, 5);
         ae->updates_id = sqlite3_column_int(res, 6);

--- a/health/health.c
+++ b/health/health.c
@@ -230,6 +230,7 @@ void health_reload(void) {
     if (netdata_cloud_setting) {
         aclk_single_update_enable();
         aclk_alarm_reload();
+        aclk_alert_reloaded = 1;
     }
 #endif
 }
@@ -1007,6 +1008,13 @@ void *health_main(void *ptr) {
                 }
 
                 rrdhost_unlock(host);
+
+#ifdef ENABLE_ACLK
+                if (netdata_cloud_setting && aclk_alert_reloaded) {
+                    sql_queue_removed_alerts_to_aclk(host);
+                    aclk_alert_reloaded = 0;
+                }
+#endif
             }
 
             if (unlikely(netdata_exit))


### PR DESCRIPTION
When the agent starts, after the first health loop, it will check if there are pending REMOVED alerts in health_log and will queue to the cloud.

On health reload, it will set `aclk_alert_reloaded` to `1` to trigger the same function.